### PR TITLE
Upgrade fast-uri to 3.1.2 (CVE-2026-6321, CVE-2026-6322)

### DIFF
--- a/apps/nar-v3/package-lock.json
+++ b/apps/nar-v3/package-lock.json
@@ -4808,9 +4808,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -14517,9 +14517,9 @@
       "dev": true
     },
     "fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "peer": true
     },
     "fastq": {


### PR DESCRIPTION
Upgrades the transitive dependency `fast-uri` (via `ajv`) from 3.1.0 to 3.1.2 in `apps/nar-v3/package-lock.json`.

Fixes two high-severity vulnerabilities:
- **CVE-2026-6321** — Path traversal via percent-encoded dot segments (fixed in 3.1.1)
- **CVE-2026-6322** — Host confusion via percent-encoded authority delimiters (fixed in 3.1.2)